### PR TITLE
Remove login app bar and fix user type

### DIFF
--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -32,7 +32,10 @@ class _LoginScreenState extends State<LoginScreen> {
       );
 
       if (result['success']) {
-        final userType = result['userType'];
+        String? userType = result['userType'];
+        if (userType == null) {
+          userType = await _authService.getUserType();
+        }
         if (userType == null) {
           _showMessage('لم يتم تحديد نوع المستخدم', isError: true);
           return;
@@ -84,14 +87,6 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.grey[50],
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios, color: Colors.black87),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
       body: SafeArea(
         child: Directionality(
           textDirection: TextDirection.rtl,


### PR DESCRIPTION
## Summary
- adjust login logic to fetch user type from storage if login response lacks it
- remove the AppBar from the login screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685028693960833088952acf0b0cf7c7