### PR TITLE
Implement real estate office registration

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -68,6 +68,37 @@ class AuthProvider with ChangeNotifier {
     return result;
   }
 
+  // تحديث بيانات مكتب العقارات - الخطوة الثانية
+  Future<Map<String, dynamic>> registerRealstateOfficeStep2({
+    required String phone,
+    required String address,
+    required String officeLogo,
+    required String ownerIdFront,
+    required String ownerIdBack,
+    required String officeImage,
+    required String commercialCardFront,
+    required String commercialCardBack,
+    required bool vat,
+  }) async {
+    final result = await _authService.registerRealstateOfficeStep2(
+      phone: phone,
+      address: address,
+      officeLogo: officeLogo,
+      ownerIdFront: ownerIdFront,
+      ownerIdBack: ownerIdBack,
+      officeImage: officeImage,
+      commercialCardFront: commercialCardFront,
+      commercialCardBack: commercialCardBack,
+      vat: vat,
+    );
+
+    if (result['success']) {
+      await _loadUserSession();
+    }
+
+    return result;
+  }
+
   // تسجيل مستخدم جديد وإنشاء app user مباشرة
   Future<Map<String, dynamic>> registerUser({
     required String username,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -109,6 +109,79 @@ class AuthService {
     }
   }
 
+  // تحديث بيانات حساب مكتب عقاري - الخطوة الثانية
+  Future<Map<String, dynamic>> registerRealstateOfficeStep2({
+    required String phone,
+    required String address,
+    required String officeLogo,
+    required String ownerIdFront,
+    required String ownerIdBack,
+    required String officeImage,
+    required String commercialCardFront,
+    required String commercialCardBack,
+    required bool vat,
+  }) async {
+    try {
+      final token = await getToken();
+      if (token == null) {
+        return {
+          'success': false,
+          'message': 'يجب تسجيل الدخول أولاً',
+        };
+      }
+
+      final userData = await getUserData();
+      if (userData == null) {
+        return {
+          'success': false,
+          'message': 'بيانات المستخدم غير متوفرة',
+        };
+      }
+
+      final userId = userData['id'];
+
+      final response = await http.put(
+        Uri.parse('$baseUrl/api/users/$userId'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode({
+          'type': 'RealstateOffice',
+          'phone': phone,
+          'RealstateOfficeAddress': address,
+          'RealstateOfficeLogo': officeLogo,
+          'RealstateOfficeOwnerIdFront': ownerIdFront,
+          'RealstateOfficeOwnerIdBack': ownerIdBack,
+          'RealstateOfficeImage': officeImage,
+          'RealstateOfficeCommercialCardFront': commercialCardFront,
+          'RealstateOfficeCommercialCardBack': commercialCardBack,
+          'Vat': vat,
+        }),
+      );
+
+      final responseData = jsonDecode(response.body);
+
+      if (response.statusCode == 200) {
+        await _updateUserData(responseData);
+        return {
+          'success': true,
+          'data': responseData,
+        };
+      } else {
+        return {
+          'success': false,
+          'message': responseData['error']?['message'] ?? 'فشل إنشاء بيانات المكتب',
+        };
+      }
+    } catch (e) {
+      return {
+        'success': false,
+        'message': 'خطأ في الاتصال بالخادم: $e',
+      };
+    }
+  }
+
   // تسجيل مستخدم جديد وإنشاء سجل app user وربطه بالحساب
   Future<Map<String, dynamic>> registerUser({
     required String username,

--- a/lib/services/strapi_service.dart
+++ b/lib/services/strapi_service.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class StrapiService {
+  static const String baseUrl = 'http://192.168.1.12:1337';
+
+  Future<String?> uploadFile(String filePath, String token) async {
+    final uri = Uri.parse('$baseUrl/api/upload');
+    final request = http.MultipartRequest('POST', uri);
+    request.headers['Authorization'] = 'Bearer $token';
+    request.files.add(await http.MultipartFile.fromPath('files', filePath));
+    final response = await request.send();
+    final responseBody = await response.stream.bytesToString();
+    if (response.statusCode == 200) {
+      final data = jsonDecode(responseBody);
+      if (data is List && data.isNotEmpty) {
+        return data[0]['url'] as String?;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- handle media uploads via new `StrapiService`
- extend `AuthService` and `AuthProvider` with office registration logic
- implement full form validation and registration flow in `SubscriptionRegistrationOfficeScreen`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0b255e08330a060c1b9ec04dcbe