### PR TITLE
Update city field and home UI

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -54,11 +54,11 @@ class AuthProvider with ChangeNotifier {
   // تحديث بيانات المستخدم - الخطوة الثانية
   Future<Map<String, dynamic>> registerStep2({
     required String userPhone,
-    required String userCity,
+    required String city,
   }) async {
     final result = await _authService.registerStep2(
       userPhone: userPhone,
-      userCity: userCity,
+      city: city,
     );
 
     if (result['success']) {
@@ -105,20 +105,29 @@ class AuthProvider with ChangeNotifier {
     required String email,
     required String password,
     required String userPhone,
-    required String userCity,
+    required String city,
   }) async {
     final result = await _authService.registerUser(
       username: username,
       email: email,
       password: password,
       userPhone: userPhone,
-      userCity: userCity,
+      city: city,
     );
 
     if (result['success']) {
       await _loadUserSession();
     }
 
+    return result;
+  }
+
+  // تحديث المدينة الحالية
+  Future<Map<String, dynamic>> updateCity(String city) async {
+    final result = await _authService.updateCity(city);
+    if (result['success']) {
+      await _loadUserSession();
+    }
     return result;
   }
 

--- a/lib/screens/auth/register_user_screen.dart
+++ b/lib/screens/auth/register_user_screen.dart
@@ -146,7 +146,7 @@ class _RegisterUserScreenState extends State<RegisterUserScreen> {
         email: _emailController.text.trim(),
         password: _passwordController.text,
         userPhone: _phoneController.text.trim(),
-        userCity: _selectedCity!,
+        city: _selectedCity!,
       );
 
       if (result['success']) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   url_launcher: 6.1.10
   flutter_native_splash: 2.4.6
   http: 1.4.0
+  cached_network_image: 3.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- rename `userCity` field to `city` across auth service and provider
- add ability to update city
- adjust register screen to use new `city` field
- enhance user home screen with RTL layout, city dropdown, icons and a network slider
- add `cached_network_image` dependency for better image caching

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856da2789d08330a7816a0c2f14c567