### PR TITLE
Use IDs for media files

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -72,12 +72,12 @@ class AuthProvider with ChangeNotifier {
   Future<Map<String, dynamic>> registerRealstateOfficeStep2({
     required String phone,
     required String address,
-    required String officeLogo,
-    required String ownerIdFront,
-    required String ownerIdBack,
-    required String officeImage,
-    required String commercialCardFront,
-    required String commercialCardBack,
+    required int officeLogo,
+    required int ownerIdFront,
+    required int ownerIdBack,
+    required int officeImage,
+    required int commercialCardFront,
+    required int commercialCardBack,
     required bool vat,
   }) async {
     final result = await _authService.registerRealstateOfficeStep2(

--- a/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
+++ b/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
@@ -109,20 +109,20 @@ class _SubscriptionRegistrationOfficeScreenState
 
     final strapiService = StrapiService();
 
-    final officeLogoUrl = await strapiService.uploadFile(_officeLogoPath!, token);
-    final ownerIdFrontUrl = await strapiService.uploadFile(_ownerIdFrontPath!, token);
-    final ownerIdBackUrl = await strapiService.uploadFile(_ownerIdBackPath!, token);
-    final officePhotoUrl = await strapiService.uploadFile(_officePhotoFrontPath!, token);
-    final crFrontUrl = await strapiService.uploadFile(_crPhotoFrontPath!, token);
-    final crBackUrl = await strapiService.uploadFile(_crPhotoBackPath!, token);
+    final officeLogoId = await strapiService.uploadMedia(_officeLogoPath!, token);
+    final ownerIdFrontId = await strapiService.uploadMedia(_ownerIdFrontPath!, token);
+    final ownerIdBackId = await strapiService.uploadMedia(_ownerIdBackPath!, token);
+    final officePhotoId = await strapiService.uploadMedia(_officePhotoFrontPath!, token);
+    final crFrontId = await strapiService.uploadMedia(_crPhotoFrontPath!, token);
+    final crBackId = await strapiService.uploadMedia(_crPhotoBackPath!, token);
 
     if ([
-          officeLogoUrl,
-          ownerIdFrontUrl,
-          ownerIdBackUrl,
-          officePhotoUrl,
-          crFrontUrl,
-          crBackUrl
+          officeLogoId,
+          ownerIdFrontId,
+          ownerIdBackId,
+          officePhotoId,
+          crFrontId,
+          crBackId
         ].any((u) => u == null)) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('فشل رفع الملفات')));
@@ -132,12 +132,12 @@ class _SubscriptionRegistrationOfficeScreenState
     final step2 = await authProvider.registerRealstateOfficeStep2(
       phone: _phoneController.text.trim(),
       address: _addressController.text.trim(),
-      officeLogo: officeLogoUrl!,
-      ownerIdFront: ownerIdFrontUrl!,
-      ownerIdBack: ownerIdBackUrl!,
-      officeImage: officePhotoUrl!,
-      commercialCardFront: crFrontUrl!,
-      commercialCardBack: crBackUrl!,
+      officeLogo: officeLogoId!,
+      ownerIdFront: ownerIdFrontId!,
+      ownerIdBack: ownerIdBackId!,
+      officeImage: officePhotoId!,
+      commercialCardFront: crFrontId!,
+      commercialCardBack: crBackId!,
       vat: _includesVat,
     );
 

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -113,12 +113,12 @@ class AuthService {
   Future<Map<String, dynamic>> registerRealstateOfficeStep2({
     required String phone,
     required String address,
-    required String officeLogo,
-    required String ownerIdFront,
-    required String ownerIdBack,
-    required String officeImage,
-    required String commercialCardFront,
-    required String commercialCardBack,
+    required int officeLogo,
+    required int ownerIdFront,
+    required int ownerIdBack,
+    required int officeImage,
+    required int commercialCardFront,
+    required int commercialCardBack,
     required bool vat,
   }) async {
     try {

--- a/lib/services/strapi_service.dart
+++ b/lib/services/strapi_service.dart
@@ -4,7 +4,8 @@ import 'package:http/http.dart' as http;
 class StrapiService {
   static const String baseUrl = 'http://192.168.1.12:1337';
 
-  Future<String?> uploadFile(String filePath, String token) async {
+  /// Uploads a file to Strapi and returns the media ID when successful.
+  Future<int?> uploadMedia(String filePath, String token) async {
     final uri = Uri.parse('$baseUrl/api/upload');
     final request = http.MultipartRequest('POST', uri);
     request.headers['Authorization'] = 'Bearer $token';
@@ -14,7 +15,7 @@ class StrapiService {
     if (response.statusCode == 200) {
       final data = jsonDecode(responseBody);
       if (data is List && data.isNotEmpty) {
-        return data[0]['url'] as String?;
+        return data[0]['id'] as int?;
       }
     }
     return null;


### PR DESCRIPTION
## Summary
- modify Strapi service to return uploaded media ID
- update office registration screen to upload media first and pass IDs
- adjust provider and auth service to accept media IDs instead of URLs

## Testing
- `dart format -o none --set-exit-if-changed lib providers test` *(fails: `dart: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857470d47308330ba7e54d7f469c6a8