### PR TITLE
Add basic profile screen

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -25,6 +25,7 @@ import 'package:saba2v2/screens/business/RealStateScreens/RealStateHomeScreen.da
 import 'package:saba2v2/screens/splash/splash_screen.dart';
 import 'package:saba2v2/screens/auth/forgotPassword.dart';
 import 'package:saba2v2/screens/user/user_home_screen.dart';
+import 'package:saba2v2/screens/user/profile_screen.dart';
 import 'package:saba2v2/screens/business/CarsScreens/delivery_office_information.dart';
 
 class AppRouter {
@@ -209,6 +210,11 @@ class AppRouter {
         path: '/UserHomeScreen',
         name: 'UserHomeScreen',
         builder: (context, state) => const UserHomeScreen(),
+      ),
+      GoRoute(
+        path: '/profile',
+        name: 'profile',
+        builder: (context, state) => const ProfileScreen(),
       ),
 
       // **********************************************************************

--- a/lib/screens/user/profile_screen.dart
+++ b/lib/screens/user/profile_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
+import 'package:saba2v2/providers/auth_provider.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  Future<void> _logout(BuildContext context) async {
+    await context.read<AuthProvider>().logout();
+    if (context.mounted) {
+      context.go('/login');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('الملف الشخصي'),
+        ),
+        body: Center(
+          child: ElevatedButton(
+            onPressed: () => _logout(context),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.orange,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+            ),
+            child: const Text('تسجيل الخروج'),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple `ProfileScreen` with a logout button
- register `/profile` route in the router

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857484565dc8330943e6c3441ccd45b