### PR TITLE
Update router rules for registration pages

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -44,7 +44,10 @@ class AppRouter {
             state.matchedLocation != '/register-provider' &&
             state.matchedLocation != '/forgotPassword' &&
             state.matchedLocation != '/onboarding' &&
-            state.matchedLocation != '/SplashScreen') {
+            state.matchedLocation != '/SplashScreen' &&
+            state.matchedLocation != '/ResturantLawData' &&
+            state.matchedLocation != '/subscription-registration' &&
+            state.matchedLocation != '/delivery-registration') {
           return '/login';
         }
 


### PR DESCRIPTION
## Summary
- allow `/ResturantLawData`, `/subscription-registration` and `/delivery-registration` to be reached without logging in

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68574a85e1308330a6519b561d81d95a