### PR TITLE
Fix image upload permission handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,9 @@
         </intent>
     </queries>
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Permissions required for picking images from the device -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
 
 </manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,7 +47,11 @@
 		<true/>
 		<key>UIStatusBarHidden</key>
 		<true/>
-		<key>UIViewControllerBasedStatusBarAppearance</key>
-		<false/>
-	</dict>
+                <key>UIViewControllerBasedStatusBarAppearance</key>
+                <false/>
+                <key>NSPhotoLibraryUsageDescription</key>
+                <string>يحتاج التطبيق إلى الوصول إلى الصور لاختيار ملفات التحميل</string>
+                <key>NSPhotoLibraryAddUsageDescription</key>
+                <string>يتيح هذا الإذن حفظ الصور بعد اختيارها</string>
+        </dict>
 </plist>

--- a/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
+++ b/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'dart:io';
 import 'package:saba2v2/components/UI/image_picker_row.dart';
 import 'package:saba2v2/components/UI/section_title.dart';
 import 'package:saba2v2/providers/auth_provider.dart';
@@ -36,6 +38,17 @@ class _SubscriptionRegistrationOfficeScreenState
   String? _crPhotoBackPath;
 
   Future<void> _pickFile(String fieldName) async {
+    final permission = Platform.isIOS ? Permission.photos : Permission.storage;
+    final status = await permission.request();
+    if (!status.isGranted) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('الرجاء منح صلاحية الوصول للصور')),
+        );
+      }
+      return;
+    }
+
     final result = await FilePicker.platform.pickFiles(type: FileType.image);
     if (result != null && result.files.isNotEmpty) {
       final path = result.files.single.path;


### PR DESCRIPTION
## Summary
- request gallery/storage permission before selecting images
- add android read permissions for photos
- include iOS photo library usage descriptions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685751ad12108330a72e18127bade32e