### PR TITLE
Improve image selection feedback

### DIFF
--- a/lib/components/UI/image_picker_row.dart
+++ b/lib/components/UI/image_picker_row.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'dart:io';
 
 class ImagePickerRow extends StatelessWidget {
   final String label;
   final IconData icon;
   final String fieldIdentifier;
   final VoidCallback onTap;
+  final String? imagePath;
+  final VoidCallback? onRemove;
 
   const ImagePickerRow({
     super.key,
@@ -12,36 +15,80 @@ class ImagePickerRow extends StatelessWidget {
     required this.icon,
     required this.fieldIdentifier,
     required this.onTap,
+    this.imagePath,
+    this.onRemove,
   });
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(12.0),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-        decoration: BoxDecoration(
-          color: Colors.orange.shade50,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        InkWell(
+          onTap: onTap,
           borderRadius: BorderRadius.circular(12.0),
-          border: Border.all(color: Colors.orange.shade100, width: 1),
-        ),
-        child: Directionality(
-          textDirection: TextDirection.rtl,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-
-            children: [
-              Text(
-                label,
-                style: TextStyle(fontSize: 16, color: Colors.grey[700]),
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+            decoration: BoxDecoration(
+              color: Colors.orange.shade50,
+              borderRadius: BorderRadius.circular(12.0),
+              border: Border.all(color: Colors.orange.shade100, width: 1),
+            ),
+            child: Directionality(
+              textDirection: TextDirection.rtl,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    label,
+                    style: TextStyle(fontSize: 16, color: Colors.grey[700]),
+                  ),
+                  const SizedBox(width: 12),
+                  Icon(icon, color: Colors.orange, size: 28),
+                ],
               ),
-              const SizedBox(width: 12),
-              Icon(icon, color: Colors.orange, size: 28),
-            ],
+            ),
           ),
         ),
-      ),
+        if (imagePath != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: Stack(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.file(
+                    File(imagePath!),
+                    height: 100,
+                    width: 100,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+                if (onRemove != null)
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: InkWell(
+                      onTap: onRemove,
+                      child: Container(
+                        decoration: const BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: Colors.black54,
+                        ),
+                        padding: const EdgeInsets.all(2),
+                        child: const Icon(
+                          Icons.close,
+                          color: Colors.white,
+                          size: 16,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/screens/business/CarsScreens/driver_car_info.dart
+++ b/lib/screens/business/CarsScreens/driver_car_info.dart
@@ -76,6 +76,31 @@ class _DriverCarInfoState extends State<DriverCarInfo> {
     });
   }
 
+  void _removeImage(String fieldIdentifier) {
+    setState(() {
+      switch (fieldIdentifier) {
+        case 'license_front':
+          _licenseFrontImagePath = null;
+          break;
+        case 'license_back':
+          _licenseBackImagePath = null;
+          break;
+        case 'car_registration_front':
+          _carRegistrationFrontImagePath = null;
+          break;
+        case 'car_registration_back':
+          _carRegistrationBackImagePath = null;
+          break;
+        case 'car_front':
+          _carFrontImagePath = null;
+          break;
+        case 'car_back':
+          _carBackImagePath = null;
+          break;
+      }
+    });
+  }
+
   // Form Submission
   void _onSubmit() {
     if (_formKey.currentState!.validate()) {
@@ -143,6 +168,8 @@ class _DriverCarInfoState extends State<DriverCarInfo> {
               icon: Icons.camera_alt,
               fieldIdentifier: fieldIdentifier,
               onTap: () => _pickImage(fieldIdentifier),
+              imagePath: imagePath,
+              onRemove: () => _removeImage(fieldIdentifier),
             ),
             if (validator(imagePath) != null)
               Padding(

--- a/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
+++ b/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
@@ -95,6 +95,31 @@ class _SubscriptionRegistrationOfficeScreenState
     }
   }
 
+  void _removeFile(String fieldName) {
+    setState(() {
+      switch (fieldName) {
+        case 'officeLogo':
+          _officeLogoPath = null;
+          break;
+        case 'ownerIdFront':
+          _ownerIdFrontPath = null;
+          break;
+        case 'ownerIdBack':
+          _ownerIdBackPath = null;
+          break;
+        case 'officePhotoFront':
+          _officePhotoFrontPath = null;
+          break;
+        case 'crPhotoFront':
+          _crPhotoFrontPath = null;
+          break;
+        case 'crPhotoBack':
+          _crPhotoBackPath = null;
+          break;
+      }
+    });
+  }
+
   Future<void> _submitForm() async {
     if (!_formKey.currentState!.validate()) return;
 
@@ -272,6 +297,8 @@ class _SubscriptionRegistrationOfficeScreenState
                 icon: Icons.image_outlined,
                 fieldIdentifier: 'officeLogo',
                 onTap: () => _pickFile('officeLogo'),
+                imagePath: _officeLogoPath,
+                onRemove: () => _removeFile('officeLogo'),
               ),
 
               // Section 2: Owner ID
@@ -285,6 +312,8 @@ class _SubscriptionRegistrationOfficeScreenState
                 icon: Icons.image_outlined,
                 fieldIdentifier: 'ownerIdFront',
                 onTap: () => _pickFile('ownerIdFront'),
+                imagePath: _ownerIdFrontPath,
+                onRemove: () => _removeFile('ownerIdFront'),
               ),
               const SizedBox(height: 12),
               ImagePickerRow(
@@ -292,6 +321,8 @@ class _SubscriptionRegistrationOfficeScreenState
                 icon: Icons.image_outlined,
                 fieldIdentifier: 'ownerIdBack',
                 onTap: () => _pickFile('ownerIdBack'),
+                imagePath: _ownerIdBackPath,
+                onRemove: () => _removeFile('ownerIdBack'),
               ),
 
               // Section 3: Office Photos
@@ -305,6 +336,8 @@ class _SubscriptionRegistrationOfficeScreenState
                 icon: Icons.image_outlined,
                 fieldIdentifier: 'officePhotoFront',
                 onTap: () => _pickFile('officePhotoFront'),
+                imagePath: _officePhotoFrontPath,
+                onRemove: () => _removeFile('officePhotoFront'),
               ),
 
               // Section 4: Commercial Register
@@ -318,6 +351,8 @@ class _SubscriptionRegistrationOfficeScreenState
                 icon: Icons.image_outlined,
                 fieldIdentifier: 'crPhotoFront',
                 onTap: () => _pickFile('crPhotoFront'),
+                imagePath: _crPhotoFrontPath,
+                onRemove: () => _removeFile('crPhotoFront'),
               ),
               const SizedBox(height: 12),
               ImagePickerRow(
@@ -325,6 +360,8 @@ class _SubscriptionRegistrationOfficeScreenState
                 icon: Icons.image_outlined,
                 fieldIdentifier: 'crPhotoBack',
                 onTap: () => _pickFile('crPhotoBack'),
+                imagePath: _crPhotoBackPath,
+                onRemove: () => _removeFile('crPhotoBack'),
               ),
 
               // Section 5: VAT


### PR DESCRIPTION
## Summary
- show preview thumbnails in `ImagePickerRow`
- allow removing a previously picked image
- wire up image preview/remove for Real Estate Office and Car Info screens

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685756cba9908330a31d19ab9bd1cea1