### PR TITLE
Add province dropdown to real estate office signup

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -71,6 +71,7 @@ class AuthProvider with ChangeNotifier {
   // تحديث بيانات مكتب العقارات - الخطوة الثانية
   Future<Map<String, dynamic>> registerRealstateOfficeStep2({
     required String phone,
+    required String city,
     required String address,
     required int officeLogo,
     required int ownerIdFront,
@@ -90,6 +91,7 @@ class AuthProvider with ChangeNotifier {
       commercialCardFront: commercialCardFront,
       commercialCardBack: commercialCardBack,
       vat: vat,
+      city: city,
     );
 
     if (result['success']) {

--- a/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
+++ b/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
@@ -37,6 +37,20 @@ class _SubscriptionRegistrationOfficeScreenState
   String? _crPhotoFrontPath;
   String? _crPhotoBackPath;
 
+  String? _selectedCity;
+  final List<String> _cities = [
+    'الرياض',
+    'جدة',
+    'مكة المكرمة',
+    'المدينة المنورة',
+    'الدمام',
+    'الخبر',
+    'تبوك',
+    'أبها',
+    'القصيم',
+    'حائل',
+  ];
+
   Future<void> _pickFile(String fieldName) async {
     // On Android 13+ the `photos` permission maps to READ_MEDIA_IMAGES.
     // Older Android versions still rely on the storage permission so we
@@ -186,6 +200,7 @@ class _SubscriptionRegistrationOfficeScreenState
 
     final step2 = await authProvider.registerRealstateOfficeStep2(
       phone: _phoneController.text.trim(),
+      city: _selectedCity!,
       address: _addressController.text.trim(),
       officeLogo: officeLogoId!,
       ownerIdFront: ownerIdFrontId!,
@@ -274,6 +289,48 @@ class _SubscriptionRegistrationOfficeScreenState
               _buildFormField(
                 hintText: 'رقم الهاتف',
                 controller: _phoneController,
+              ),
+              const SizedBox(height: 16),
+              Directionality(
+                textDirection: TextDirection.rtl,
+                child: DropdownButtonFormField<String>(
+                  value: _selectedCity,
+                  alignment: AlignmentDirectional.centerEnd,
+                  decoration: InputDecoration(
+                    labelText: 'المحافظة',
+                    filled: true,
+                    fillColor: Colors.grey[100],
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12.0),
+                      borderSide: BorderSide.none,
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      vertical: 15.0,
+                      horizontal: 20.0,
+                    ),
+                  ),
+                  icon: const Padding(
+                    padding: EdgeInsets.only(left: 12.0),
+                    child: Icon(Icons.keyboard_arrow_down),
+                  ),
+                  iconSize: 28,
+                  iconEnabledColor: Colors.grey[600],
+                  items: _cities.map((String city) {
+                    return DropdownMenuItem<String>(
+                      value: city,
+                      alignment: AlignmentDirectional.centerEnd,
+                      child: Text(
+                        city,
+                        textAlign: TextAlign.right,
+                        style: const TextStyle(fontSize: 16),
+                      ),
+                    );
+                  }).toList(),
+                  onChanged: (String? newValue) {
+                    setState(() => _selectedCity = newValue);
+                  },
+                  validator: (value) => value == null ? 'الرجاء اختيار المحافظة' : null,
+                ),
               ),
               const SizedBox(height: 16),
               _buildFormField(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -112,6 +112,7 @@ class AuthService {
   // تحديث بيانات حساب مكتب عقاري - الخطوة الثانية
   Future<Map<String, dynamic>> registerRealstateOfficeStep2({
     required String phone,
+    required String city,
     required String address,
     required int officeLogo,
     required int ownerIdFront,
@@ -149,6 +150,7 @@ class AuthService {
         body: jsonEncode({
           'type': 'RealstateOffice',
           'phone': phone,
+          'city': city,
           'RealstateOfficeAddress': address,
           'RealstateOfficeLogo': officeLogo,
           'RealstateOfficeOwnerIdFront': ownerIdFront,


### PR DESCRIPTION
## Summary
- add dropdown for provinces on office signup screen
- store selected value in `city` field and send it to backend
- update provider and service to handle `city` parameter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d33ac0688330875ccbd96328df07