### PR TITLE
Simplify real estate registration

### DIFF
--- a/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
+++ b/lib/screens/business/RealStateScreens/SubscriptionRegistrationOfficeScreen.dart
@@ -169,21 +169,14 @@ class _SubscriptionRegistrationOfficeScreenState
       return;
     }
 
-    final token = authProvider.token;
-    if (token == null) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('خطأ في الجلسة')));
-      return;
-    }
-
     final strapiService = StrapiService();
 
-    final officeLogoId = await strapiService.uploadMedia(_officeLogoPath!, token);
-    final ownerIdFrontId = await strapiService.uploadMedia(_ownerIdFrontPath!, token);
-    final ownerIdBackId = await strapiService.uploadMedia(_ownerIdBackPath!, token);
-    final officePhotoId = await strapiService.uploadMedia(_officePhotoFrontPath!, token);
-    final crFrontId = await strapiService.uploadMedia(_crPhotoFrontPath!, token);
-    final crBackId = await strapiService.uploadMedia(_crPhotoBackPath!, token);
+    final officeLogoId = await strapiService.uploadMedia(_officeLogoPath!);
+    final ownerIdFrontId = await strapiService.uploadMedia(_ownerIdFrontPath!);
+    final ownerIdBackId = await strapiService.uploadMedia(_ownerIdBackPath!);
+    final officePhotoId = await strapiService.uploadMedia(_officePhotoFrontPath!);
+    final crFrontId = await strapiService.uploadMedia(_crPhotoFrontPath!);
+    final crBackId = await strapiService.uploadMedia(_crPhotoBackPath!);
 
     if ([
           officeLogoId,

--- a/lib/services/strapi_service.dart
+++ b/lib/services/strapi_service.dart
@@ -4,11 +4,18 @@ import 'package:http/http.dart' as http;
 class StrapiService {
   static const String baseUrl = 'http://192.168.1.12:1337';
 
+  /// API token with full privileges used for pre-account actions.
+  static const String adminApiToken =
+      '93474d3881c0274f78c97c281d3a178cfbb139fe90794f42f4ae45bf7aae5f6f0277050f1e27dcc841a35fe14fb14a9fc6ce35a4528fa0738767a6f5233cdaecf2c23b088cdb891316218a6af07a8cafb2b57f4cbdcc9e18bec5b959537b40e91541df94696c7183ebf30981ae209a78b27c2f55d283064cca8097ab774b2c2b';
+
   /// Uploads a file to Strapi and returns the media ID when successful.
-  Future<int?> uploadMedia(String filePath, String token) async {
+  ///
+  /// If no [token] is provided, the [adminApiToken] is used.
+  Future<int?> uploadMedia(String filePath, {String? token}) async {
+    final authToken = token ?? adminApiToken;
     final uri = Uri.parse('$baseUrl/api/upload');
     final request = http.MultipartRequest('POST', uri);
-    request.headers['Authorization'] = 'Bearer $token';
+    request.headers['Authorization'] = 'Bearer $authToken';
     request.files.add(await http.MultipartFile.fromPath('files', filePath));
     final response = await request.send();
     final responseBody = await response.stream.bytesToString();


### PR DESCRIPTION
## Summary
- add admin API token handling in StrapiService
- use admin token in AuthService when uploading media and updating RealstateOffice data
- store RealstateOffice media fields directly on the user
- simplify registration screen to use admin token automatically

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685963170484833085e47114e5aa8dc6