### PR TITLE
Fix dropdown selected city mismatch

### DIFF
--- a/lib/screens/user/user_home_screen.dart
+++ b/lib/screens/user/user_home_screen.dart
@@ -65,7 +65,12 @@ class _UserHomeScreenState extends State<UserHomeScreen> {
   void initState() {
     super.initState();
     final authProvider = context.read<AuthProvider>();
-    _selectedCity = authProvider.userData?['city'] ?? _cities.first;
+    final storedCity = authProvider.userData?['city'];
+    if (storedCity != null && _cities.contains(storedCity)) {
+      _selectedCity = storedCity;
+    } else {
+      _selectedCity = _cities.first;
+    }
     Timer.periodic(const Duration(seconds: 3), (timer) {
       if (_pageController.positions.isNotEmpty) {
         _currentPage = (_currentPage + 1) % _sliderImages.length;


### PR DESCRIPTION
## Summary
- ensure user's stored city exists in predefined list before assigning

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597616e25c8330b6cc0d7541cc623a